### PR TITLE
fix: instantiate script on linux, account address cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 *.log*
+.archway
 .nuxt
 .nitro
 .cache

--- a/README.md
+++ b/README.md
@@ -27,24 +27,7 @@ npm install -g @archwayhq/cli@pre
 
 ## Environment Setup
 
-The Archway CLI is now installed and allows easy configurations to interact with the Archway blockchain. First of all decide which network you want to deploy to; Mainnet (`archway-1`) or Testnet (`constantine-3`).
-
-Check that you have the correct `chain-id` configured:
-
-```bash
-# Check the chain-id currently setup on the config
-archway config show
-```
-
-Change the chain-id config with the following command:
-
-```bash
-# For archway testnet the chain id should be 'constantine-3'
-archway config chain-id constantine-3 --global
-
-# For archway mainnet the chain id should be 'archway-1'
-archway config chain-id archway-1 --global
-```
+The Archway CLI is now installed and allows easy configurations to interact with the Archway blockchain.
 
 Copy the `.env.example` into a new `env` file with the following command:
 

--- a/scripts/instantiate/README.md
+++ b/scripts/instantiate/README.md
@@ -28,13 +28,25 @@
 
 2. Run the following command to instantiate the contracts on Constantine:
   ```
-  bash multisig_contracts_result.json
+  bash instantiate_contracts.json
   ```
 
   To instantiate them on Archway mainnet, add the `--mainnet` flag, like this:
   ```
-  bash multisig_contracts_result.json --mainnet
+  bash instantiate_contracts.json --mainnet
   ```
+
+  To instantiate them on Titus devnet, add the `--titus` flag, like this:
+  ```
+  bash instantiate_contracts.json --titus
+  ```
+
+Alternatively you can set the RUNTIME_ENVIRONMENT variable in a `.env` file at the root of this project, with any of the 3 options:
+  ```
+  # .env
+  RUNTIME_ENVIRONMENT=mainnet|testnet|titus
+  ```
+
 
 3. If successful, the transaction hash, and the result contract addresses will be displayed.
 Also a file named `multisig_contracts_result.json` will be created, containing the contract addresses.

--- a/scripts/instantiate/utils.sh
+++ b/scripts/instantiate/utils.sh
@@ -50,10 +50,10 @@ function instantiate-multisig-contract() {
     }'
   )"
 
-  encoded_voting_inst_msg="$(base64 <<< "${voting_instantiate_msg}")"
+  encoded_voting_inst_msg="$(base64 <<< "${voting_instantiate_msg}" | tr -d \\n)"
 
   prepropose_info='{"deposit_info":null,"extension":{},"open_proposal_submission":false}'
-  encoded_prepropose_info="$(base64 <<< "${prepropose_info}")"
+  encoded_prepropose_info="$(base64 <<< "${prepropose_info}"| tr -d \\n)"
 
 
   proposal_instantiate_msg="$(
@@ -96,7 +96,7 @@ function instantiate-multisig-contract() {
       }'
     )"
 
-  encoded_proposal_inst_msg="$(base64 <<< "${proposal_instantiate_msg}")"
+  encoded_proposal_inst_msg="$(base64 <<< "${proposal_instantiate_msg}"| tr -d \\n)"
 
   local instantiate_params
   instantiate_params="$(


### PR DESCRIPTION
- Remove end of line added by base64 command on linux machines
- Add titus config for the instantiate script
- Fix cache of account storing address when it may be different than the one on page reload/reopen